### PR TITLE
feat(tabs): add multi-tab sidebar with Turbo Frames

### DIFF
--- a/app/controllers/tabs_controller.rb
+++ b/app/controllers/tabs_controller.rb
@@ -1,0 +1,37 @@
+class TabsController < ApplicationController
+  def open_pr
+    pr_id = params[:pr_id]
+    session[:open_pr_tabs] ||= []
+    session[:open_pr_tabs] << pr_id unless session[:open_pr_tabs].include?(pr_id)
+    session[:active_tab] = pr_id
+    render_sidebar_and_main
+  end
+
+  def close_pr
+    pr_id = params[:pr_id]
+    session[:open_pr_tabs] ||= []
+    session[:open_pr_tabs].delete(pr_id)
+    session[:active_tab] = session[:open_pr_tabs].last || 'home'
+    render_sidebar_and_main
+  end
+
+  def select_tab
+    tab = params[:tab]
+    session[:active_tab] = tab
+    render_sidebar_and_main
+  end
+
+  private
+
+  def render_sidebar_and_main
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: [
+          turbo_stream.replace('sidebar', partial: 'layouts/sidebar'),
+          turbo_stream.replace('main_content', partial: 'layouts/main_content', locals: { tab: session[:active_tab] })
+        ]
+      end
+      format.html { redirect_to root_path }
+    end
+  end
+end

--- a/app/views/layouts/_main_content.html.erb
+++ b/app/views/layouts/_main_content.html.erb
@@ -1,0 +1,6 @@
+<main class="flex-1 bg-gray-100 p-8 overflow-y-auto">
+  <div class="text-2xl font-bold mb-4">
+    Main content for tab: <%= tab.inspect %>
+  </div>
+  <!-- Add more styled content here -->
+</main>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -1,0 +1,21 @@
+<aside class="w-64 bg-gray-900 text-white flex flex-col h-full">
+  <div class="flex flex-col flex-1">
+    <div class="p-4 border-b border-gray-800 font-bold text-lg">Pr Pal</div>
+    <nav class="flex-1 overflow-y-auto">
+      <ul>
+        <li class="px-4 py-2 hover:bg-gray-800">
+          <%= link_to 'Home', select_tab_tabs_path(tab: 'home'), data: { turbo_frame: 'main_content' }, class: "block w-full" %>
+        </li>
+        <li class="px-4 py-2 hover:bg-gray-800">
+          <%= link_to 'Pull Requests', select_tab_tabs_path(tab: 'pull_requests'), data: { turbo_frame: 'main_content' }, class: "block w-full" %>
+        </li>
+        <% (session[:open_pr_tabs] || []).each do |pr_id| %>
+        <li class="flex items-center justify-between px-4 py-2 hover:bg-gray-800">
+          <%= link_to "PR ##{pr_id}", select_tab_tabs_path(tab: pr_id), data: { turbo_frame: 'main_content' }, class: "flex-1" %>
+          <%= button_to '×', close_pr_tabs_path(pr_id: pr_id), method: :post, form: { data: { turbo_frame: 'sidebar' } }, class: 'ml-2 text-gray-400 hover:text-red-500' %>
+        </li>
+        <% end %>
+      </ul>
+    </nav>
+  </div>
+</aside>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,28 +1,40 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title><%= content_for(:title) || "Pr Pal" %></title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="mobile-web-app-capable" content="yes">
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
 
-    <%= yield :head %>
+<head>
+  <title><%= content_for(:title) || "Pr Pal" %></title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
+  <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
 
-    <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
-    <%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
+  <%= yield :head %>
 
-    <link rel="icon" href="/icon.png" type="image/png">
-    <link rel="icon" href="/icon.svg" type="image/svg+xml">
-    <link rel="apple-touch-icon" href="/icon.png">
+  <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
+  <%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
 
-    <%# Includes all stylesheet files in app/assets/stylesheets %>
-    <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
-    <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
-  </head>
+  <link rel="icon" href="/icon.png" type="image/png">
+  <link rel="icon" href="/icon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="/icon.png">
 
-  <body>
-    <%= yield %>
-  </body>
+  <%# Includes all stylesheet files in app/assets/stylesheets %>
+  <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+  <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+</head>
+
+<body>
+  <div class="flex h-screen">
+    <!-- Sidebar Frame -->
+    <turbo-frame id="sidebar">
+      <%= render 'layouts/sidebar' %>
+    </turbo-frame>
+
+    <!-- Main Content Frame -->
+    <turbo-frame id="main_content">
+      <%= render 'layouts/main_content', tab: @active_tab %>
+    </turbo-frame>
+  </div>
+</body>
+
 </html>


### PR DESCRIPTION
Introduce a sidebar with Turbo Frames to manage multiple tabs including
home, pull requests, and dynamically opened PR tabs stored in session.
Add TabsController to handle opening, closing, and selecting tabs,
updating session state and rendering sidebar and main content via
Turbo Streams. Refactor application layout to use Turbo Frames for
sidebar and main content, enabling seamless partial updates without
full page reloads. This improves user experience by allowing quick
navigation and management of multiple PR tabs within the app.