### PR TITLE
test: add Codecov integration for CI coverage reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+env:
+  CI: true
+
 jobs:
   scan_ruby:
     runs-on: ubuntu-latest

--- a/Gemfile
+++ b/Gemfile
@@ -74,4 +74,5 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
   gem "simplecov", require: false
+  gem "codecov", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    codecov (0.2.12)
+      json
+      simplecov
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -438,6 +441,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   capybara
+  codecov
   cssbundling-rails
   debug
   jbuilder

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,18 @@
-
 ENV["RAILS_ENV"] ||= "test"
 require "simplecov"
+
+# Configure Codecov if running in CI
+if ENV["CI"]
+  require "codecov"
+  codecov_formatter = SimpleCov::Formatter.const_get("Codecov")
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+    SimpleCov::Formatter::HTMLFormatter,
+    codecov_formatter
+  ])
+else
+  SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
+end
+
 SimpleCov.start "rails" do
   enable_coverage :branch
   add_filter "/test/"


### PR DESCRIPTION
Add the codecov gem and configure SimpleCov to use Codecov's formatter
when running in a CI environment. This enables uploading coverage reports
to Codecov, improving visibility of test coverage across the project.