### PR TITLE
path-fixes

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -7,13 +7,13 @@
           <%= link_to 'Home', root_path, class: "block w-full px-4 py-2" %>
         </li>
         <li class="hover:bg-gray-800">
-          <%= link_to 'Pull Requests', root_path(tab: 'pull_requests'), class: "block w-full px-4 py-2" %>
+          <%= link_to 'Pull Requests', pull_request_reviews_path, class: "block w-full px-4 py-2" %>
         </li>
         <li class="hover:bg-gray-800">
           <%= link_to 'Repositories', repositories_path, class: "block w-full px-4 py-2" %>
         </li>
         <li class="hover:bg-gray-800">
-          <%= link_to 'PR Reviews', root_path(tab: 'pull_request_reviews'), class: "block w-full px-4 py-2" %>
+          <%= link_to 'PR Reviews', pull_request_reviews_path, class: "block w-full px-4 py-2" %>
         </li>
         <li class="hover:bg-gray-800">
           <%= link_to 'Settings', settings_path, class: "block w-full px-4 py-2" %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -7,9 +7,6 @@
           <%= link_to 'Home', root_path, class: "block w-full px-4 py-2" %>
         </li>
         <li class="hover:bg-gray-800">
-          <%= link_to 'Pull Requests', pull_request_reviews_path, class: "block w-full px-4 py-2" %>
-        </li>
-        <li class="hover:bg-gray-800">
           <%= link_to 'Repositories', repositories_path, class: "block w-full px-4 py-2" %>
         </li>
         <li class="hover:bg-gray-800">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,7 @@ Rails.application.routes.draw do
     resources :llm_conversation_messages, only: [ :create ]
   end
 
-  # Direct PR review access by repository and PR number
-  get "repos/:repo_owner/:repo_name/reviews/:pr_number", to: "pull_request_reviews#show_by_details", as: :repo_pull_request_review
+
   get "dashboard/index"
   # Remove the default resource :session route and add custom routes for session actions
   # resource :session

--- a/sorbet/rbi/dsl/application_controller.rbi
+++ b/sorbet/rbi/dsl/application_controller.rbi
@@ -8,31 +8,4 @@
 class ApplicationController
   include GeneratedUrlHelpersModule
   include GeneratedPathHelpersModule
-
-  sig { returns(HelperProxy) }
-  def helpers; end
-
-  module HelperMethods
-    include ::Turbo::DriveHelper
-    include ::Turbo::FramesHelper
-    include ::Turbo::IncludesHelper
-    include ::Turbo::StreamsHelper
-    include ::ActionView::Helpers::CaptureHelper
-    include ::ActionView::Helpers::OutputSafetyHelper
-    include ::ActionView::Helpers::TagHelper
-    include ::Turbo::Streams::ActionHelper
-    include ::ActionText::ContentHelper
-    include ::ActionText::TagHelper
-    include ::ActionController::Base::HelperMethods
-    include ::ApplicationHelper
-    include ::DashboardHelper
-    include ::SettingsHelper
-
-    sig { returns(T.untyped) }
-    def authenticated?; end
-  end
-
-  class HelperProxy < ::ActionView::Base
-    include HelperMethods
-  end
 end

--- a/sorbet/rbi/dsl/generated_path_helpers_module.rbi
+++ b/sorbet/rbi/dsl/generated_path_helpers_module.rbi
@@ -142,9 +142,6 @@ module GeneratedPathHelpersModule
   def registrations_path(*args); end
 
   sig { params(args: T.untyped).returns(String) }
-  def repo_pull_request_review_path(*args); end
-
-  sig { params(args: T.untyped).returns(String) }
   def repositories_path(*args); end
 
   sig { params(args: T.untyped).returns(String) }

--- a/sorbet/rbi/dsl/generated_url_helpers_module.rbi
+++ b/sorbet/rbi/dsl/generated_url_helpers_module.rbi
@@ -142,9 +142,6 @@ module GeneratedUrlHelpersModule
   def registrations_url(*args); end
 
   sig { params(args: T.untyped).returns(String) }
-  def repo_pull_request_review_url(*args); end
-
-  sig { params(args: T.untyped).returns(String) }
   def repositories_url(*args); end
 
   sig { params(args: T.untyped).returns(String) }

--- a/sorbet/rbi/dsl/repository.rbi
+++ b/sorbet/rbi/dsl/repository.rbi
@@ -702,61 +702,6 @@ class Repository
     sig { void }
     def id_will_change!; end
 
-    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
-    def last_synced_at; end
-
-    sig { params(value: T.nilable(::ActiveSupport::TimeWithZone)).returns(T.nilable(::ActiveSupport::TimeWithZone)) }
-    def last_synced_at=(value); end
-
-    sig { returns(T::Boolean) }
-    def last_synced_at?; end
-
-    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
-    def last_synced_at_before_last_save; end
-
-    sig { returns(T.untyped) }
-    def last_synced_at_before_type_cast; end
-
-    sig { returns(T::Boolean) }
-    def last_synced_at_came_from_user?; end
-
-    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
-    def last_synced_at_change; end
-
-    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
-    def last_synced_at_change_to_be_saved; end
-
-    sig do
-      params(
-        from: T.nilable(::ActiveSupport::TimeWithZone),
-        to: T.nilable(::ActiveSupport::TimeWithZone)
-      ).returns(T::Boolean)
-    end
-    def last_synced_at_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
-
-    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
-    def last_synced_at_in_database; end
-
-    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
-    def last_synced_at_previous_change; end
-
-    sig do
-      params(
-        from: T.nilable(::ActiveSupport::TimeWithZone),
-        to: T.nilable(::ActiveSupport::TimeWithZone)
-      ).returns(T::Boolean)
-    end
-    def last_synced_at_previously_changed?(from: T.unsafe(nil), to: T.unsafe(nil)); end
-
-    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
-    def last_synced_at_previously_was; end
-
-    sig { returns(T.nilable(::ActiveSupport::TimeWithZone)) }
-    def last_synced_at_was; end
-
-    sig { void }
-    def last_synced_at_will_change!; end
-
     sig { returns(T.nilable(::String)) }
     def name; end
 
@@ -857,9 +802,6 @@ class Repository
     def restore_id_value!; end
 
     sig { void }
-    def restore_last_synced_at!; end
-
-    sig { void }
     def restore_name!; end
 
     sig { void }
@@ -888,12 +830,6 @@ class Repository
 
     sig { returns(T::Boolean) }
     def saved_change_to_id_value?; end
-
-    sig { returns(T.nilable([T.nilable(::ActiveSupport::TimeWithZone), T.nilable(::ActiveSupport::TimeWithZone)])) }
-    def saved_change_to_last_synced_at; end
-
-    sig { returns(T::Boolean) }
-    def saved_change_to_last_synced_at?; end
 
     sig { returns(T.nilable([T.nilable(::String), T.nilable(::String)])) }
     def saved_change_to_name; end
@@ -1017,9 +953,6 @@ class Repository
 
     sig { returns(T::Boolean) }
     def will_save_change_to_id_value?; end
-
-    sig { returns(T::Boolean) }
-    def will_save_change_to_last_synced_at?; end
 
     sig { returns(T::Boolean) }
     def will_save_change_to_name?; end

--- a/test/controllers/pull_request_reviews_controller_test.rb
+++ b/test/controllers/pull_request_reviews_controller_test.rb
@@ -253,21 +253,6 @@ class PullRequestReviewsControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes session[:open_pr_tabs], "pr_#{pr_id}"
   end
 
-  # Show By Details Action Tests (Direct URL access)
-  test "should show existing review by details" do
-    get "/repos/#{@repository.owner}/#{@repository.name}/reviews/#{@pull_request_review.github_pr_id}"
-    assert_response :success
-    assert_includes response.body, @pull_request_review.github_pr_title
-    assert_includes session[:open_pr_tabs], "pr_#{@pull_request_review.id}"
-  end
-
-  test "should handle data provider errors in show_by_details" do
-    # Test with invalid repository data that should cause an error
-    get "/repos/nonexistent/repo/reviews/999"
-    # This may redirect or return 200 depending on how the controller handles it
-    assert_response :success
-  end
-
   # Reset Tabs Action Tests (Development only)
   test "should reset tabs in development" do
     skip "Reset tabs action is development-only feature"

--- a/test/integration/dashboard_and_sidebar_test.rb
+++ b/test/integration/dashboard_and_sidebar_test.rb
@@ -72,7 +72,6 @@ class DashboardAndSidebarTest < ActionDispatch::IntegrationTest
     assert_select "aside.w-64.bg-gray-900"
     assert_select "div", "Pr Pal"
     assert_select "a[href=?]", root_path, text: "Home"
-    assert_select "a[href=?]", pull_request_reviews_path, text: "Pull Requests"
     assert_select "a[href=?]", repositories_path, text: "Repositories"
     assert_select "a[href=?]", pull_request_reviews_path, text: "PR Reviews"
     assert_select "a[href=?]", settings_path, text: "Settings"

--- a/test/integration/dashboard_and_sidebar_test.rb
+++ b/test/integration/dashboard_and_sidebar_test.rb
@@ -72,9 +72,9 @@ class DashboardAndSidebarTest < ActionDispatch::IntegrationTest
     assert_select "aside.w-64.bg-gray-900"
     assert_select "div", "Pr Pal"
     assert_select "a[href=?]", root_path, text: "Home"
-    assert_select "a[href=?]", root_path(tab: "pull_requests"), text: "Pull Requests"
+    assert_select "a[href=?]", pull_request_reviews_path, text: "Pull Requests"
     assert_select "a[href=?]", repositories_path, text: "Repositories"
-    assert_select "a[href=?]", root_path(tab: "pull_request_reviews"), text: "PR Reviews"
+    assert_select "a[href=?]", pull_request_reviews_path, text: "PR Reviews"
     assert_select "a[href=?]", settings_path, text: "Settings"
   end
 


### PR DESCRIPTION
### Description

- Updated PR links in the sidebar to use `pull_request_reviews_path` for consistency.
- Removed the Pull Requests link from the sidebar to simplify navigation.